### PR TITLE
Add lang attr and meta tags based on Stripe iframes

### DIFF
--- a/src/index.template.html
+++ b/src/index.template.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
-  <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+  <meta charset="utf-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Epic</title>
   <script src="<%= htmlWebpackPlugin.options.templateParams.polyfillUrl %>"></script>
 </head>

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -3,6 +3,8 @@
 
 <head>
   <meta charset="utf-8">
+  <!-- Tell older Microsoft browsers to use Standards mode -->
+  <!-- https://msdn.microsoft.com/en-us/library/ff955275(v=vs.85).aspx -->
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Epic</title>


### PR DESCRIPTION
Based on examples of Stripe iframes

Might not make any difference but let's maximise our chances of compatibility!

- `lang="en"` (https://www.w3.org/International/questions/qa-lang-why)
- `<meta http-equiv="x-ua-compatible" content="ie=edge">`: Makes older IE versions behave in a modern way
- `<meta name="viewport" content="width=device-width, initial-scale=1">`: This is to ensure responsive display on mobile devices. https://css-tricks.com/snippets/html/responsive-meta-tag/
- There's no need for the longer `"Content-type"` meta tag: https://stackoverflow.com/questions/4696499/meta-charset-utf-8-vs-meta-http-equiv-content-type