### PR TITLE
Add crossorigin and type to preload elements

### DIFF
--- a/src/index.template.html
+++ b/src/index.template.html
@@ -9,11 +9,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Epic</title>
   <script src="<%= htmlWebpackPlugin.options.templateParams.polyfillUrl %>"></script>
-  
-  <link rel="preload" href="https://interactive.guim.co.uk/fonts/guss-webfonts/GHGuardianHeadline/GHGuardianHeadline-Bold.woff2" as="font">
-  <link rel="preload" href="https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Regular.woff2" as="font">
-  <link rel="preload" href="https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Bold.woff2" as="font">
-  <link rel="preload" href="https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextSansWeb/GuardianTextSansWeb-Medium.woff2" as="font">
+
+  <link rel="preload" href="https://interactive.guim.co.uk/fonts/guss-webfonts/GHGuardianHeadline/GHGuardianHeadline-Bold.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Regular.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Bold.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="https://interactive.guim.co.uk/fonts/guss-webfonts/GuardianTextSansWeb/GuardianTextSansWeb-Medium.woff2" as="font" type="font/woff2" crossorigin>
 </head>
 
 <body>


### PR DESCRIPTION
Avoid loading fonts twice

https://stackoverflow.com/questions/47607567/warning-that-font-preload-was-not-used-within-a-few-seconds-from-the-windows-lo

https://www.smashingmagazine.com/2016/02/preload-what-is-it-good-for/#early-loading-of-fonts

https://github.com/w3c/preload/issues/32